### PR TITLE
fix: ZStream is already resourceful, having Scope in R is not useful

### DIFF
--- a/core/src/main/scala/eventstore/EventRepository.scala
+++ b/core/src/main/scala/eventstore/EventRepository.scala
@@ -32,7 +32,7 @@ object EventRepository {
 
   trait Subscription[EventType, DoneBy] {
     def restartFromFirstEvent(lastEventToHandle: LastEventToHandle = LastEventToHandle.LastEvent): IO[Unexpected, Unit]
-    def stream: ZStream[Scope, Unexpected, EventStoreEvent[EventType, DoneBy]]
+    def stream: ZStream[Any, Unexpected, EventStoreEvent[EventType, DoneBy]]
   }
 
   object Subscription {
@@ -55,7 +55,7 @@ object EventRepository {
                 .someOrElseZIO(switchableStream.switchToEmptyPastEvents)
           }
 
-        override def stream: ZStream[Scope, Unexpected, EventStoreEvent[EventType, DoneBy]] =
+        override def stream: ZStream[Any, Unexpected, EventStoreEvent[EventType, DoneBy]] =
           switchableStream.stream.collect {
             case Message.SwitchedToPastEvents => Reset[EventType, DoneBy]()
             case Message.Event(a)             => a

--- a/core/src/main/scala/eventstore/SwitchableZStream.scala
+++ b/core/src/main/scala/eventstore/SwitchableZStream.scala
@@ -23,8 +23,8 @@ private[eventstore] class SwitchableZStream[-R, +E, +A] private (
     stateRef: Ref[StreamState[E, A]],
     commands: Queue[Command[A]]
 ) {
-  def stream: ZStream[R & Scope, E, Message[A]] =
-    ZStream.unwrap {
+  def stream: ZStream[R, E, Message[A]] =
+    ZStream.unwrapScoped[R] {
       for {
         liveQueue <- liveStream.map(Message.Event(_)).toQueue()
 


### PR DESCRIPTION
  By the way, there's no API to eliminate a Scope from a ZStream,
  so it's very inconvenient to use Scope in R.